### PR TITLE
chore: use shell provider v0.3.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,27 +1,19 @@
 services:
-  ai-contained-shell:
-    build:
-      context: .
-      pull: true
-    user: "${USER_ID:?USER_ID not set - run via ai-contained.sh}:${GROUP_ID:?GROUP_ID not set - run via ai-contained.sh}"
-    environment:
-      ALLOWED_PROVIDERS: "shell"
-    volumes:
-      - "${WORKSPACE:?WORKSPACE not set - run via ai-contained.sh}:/ai_contained:ro"
-    tmpfs:
-      - /tmp:size=512m,mode=1777
-    networks:
-      - ai-contained
-
   ai-contained:
     build:
       context: .
       pull: true
-    user: "${USER_ID:?USER_ID not set - run via ai-contained.sh}:${GROUP_ID:?GROUP_ID not set - run via ai-contained.sh}"
     environment:
-      DENIED_PROVIDERS: "shell"
+      # An experimental feature that allows all "read-only" commands and filesystem operations to
+      # occur without prompting the user.
+      #
+      # This should be safe, as mutable commands and writes to the filesystem _WILL_ be prompted
+      - EXPERIMENTAL_APPROVE_ALL_READS=yes
+    user: "${USER_ID:?USER_ID not set - run via ai-contained.sh}:${GROUP_ID:?GROUP_ID not set - run via ai-contained.sh}"
     volumes:
       - "${WORKSPACE:?WORKSPACE not set - run via ai-contained.sh}:/ai_contained"
+    tmpfs:
+      - /tmp:size=512m,mode=1777
     networks:
       - ai-contained
 
@@ -41,8 +33,6 @@ services:
     depends_on:
       ai-contained:
         condition: service_healthy
-      ai-contained-shell:
-        condition: service_healthy
     # entrypoint is used instead of command so that additional args (e.g. --resume)
     # passed via `docker compose run` are appended rather than replacing the MCP config.
     # shim_claude bootstraps /config (idempotent) and then exec's claude.
@@ -50,7 +40,7 @@ services:
       - "/usr/local/bin/shim_claude"
       - "--strict-mcp-config"
       - "--mcp-config"
-      - '{"mcpServers":{"ai-contained":{"type":"http","url":"http://ai-contained:8080/mcp"},"ai-contained-shell":{"type":"http","url":"http://ai-contained-shell:8080/mcp"}}}'
+      - '{"mcpServers":{"ai-contained":{"type":"http","url":"http://ai-contained:8080/mcp"}}}'
 
 networks:
   ai-contained:


### PR DESCRIPTION
We can now safely give the shell-provider read/write access to our workspace as `downgrade_exec` will enforce that read-only commands are allowed to run _without prompting_ and write commands will be prompted.